### PR TITLE
Lag oppsummering for hver periode i simuleringen

### DIFF
--- a/src/main/kotlin/no/nav/utsjekk/simulering/client/dto/Mapper.kt
+++ b/src/main/kotlin/no/nav/utsjekk/simulering/client/dto/Mapper.kt
@@ -7,9 +7,9 @@ import no.nav.utsjekk.kontrakter.oppdrag.Utbetalingsoppdrag
 import no.nav.utsjekk.kontrakter.oppdrag.Utbetalingsperiode
 import no.nav.utsjekk.simulering.domene.Fagområde
 import no.nav.utsjekk.simulering.domene.Periode
+import no.nav.utsjekk.simulering.domene.Postering
 import no.nav.utsjekk.simulering.domene.PosteringType
 import no.nav.utsjekk.simulering.domene.SimuleringDetaljer
-import no.nav.utsjekk.simulering.domene.SimulertPostering
 import no.nav.utsjekk.simulering.domene.hentFagområdeKoderFor
 
 object Mapper {
@@ -68,10 +68,10 @@ object Mapper {
         }
     }
 
-    private fun List<Utbetaling>.tilPosteringer(): List<SimulertPostering> {
+    private fun List<Utbetaling>.tilPosteringer(): List<Postering> {
         return this.flatMap {
             it.detaljer.map { postering ->
-                SimulertPostering(
+                Postering(
                     fagområde = Fagområde.fraKode(it.fagområde),
                     sakId = it.fagSystemId,
                     fom = postering.faktiskFom,

--- a/src/main/kotlin/no/nav/utsjekk/simulering/client/dto/SimuleringResponse.kt
+++ b/src/main/kotlin/no/nav/utsjekk/simulering/client/dto/SimuleringResponse.kt
@@ -22,11 +22,11 @@ data class Utbetaling(
     val utbetalesTilId: String,
     val forfall: LocalDate,
     val feilkonto: Boolean,
-    val detaljer: List<Postering>,
+    val detaljer: List<PosteringDto>,
 )
 
 // Tilsvarer én rad i regnskapet
-data class Postering(
+data class PosteringDto(
     val type: String,
     val faktiskFom: LocalDate,
     val faktiskTom: LocalDate,

--- a/src/main/kotlin/no/nav/utsjekk/simulering/domene/OppsummeringGenerator.kt
+++ b/src/main/kotlin/no/nav/utsjekk/simulering/domene/OppsummeringGenerator.kt
@@ -1,9 +1,61 @@
 package no.nav.utsjekk.simulering.domene
 
+import no.nav.utsjekk.simulering.api.OppsummeringForPeriode
 import no.nav.utsjekk.simulering.api.SimuleringResponsDto
+import java.time.LocalDate
+import kotlin.math.abs
 
 object OppsummeringGenerator {
     fun lagOppsummering(detaljer: SimuleringDetaljer): SimuleringResponsDto {
-        return SimuleringResponsDto(oppsummeringer = emptyList(), detaljer = detaljer)
+        val oppsummeringer =
+            detaljer.perioder.map {
+                OppsummeringForPeriode(
+                    fom = it.fom,
+                    tom = it.tom,
+                    tidligereUtbetalt = beregnTidligereUtbetalt(it.posteringer),
+                    nyUtbetaling = beregnNyUtbetaling(it.posteringer),
+                    totalEtterbetaling = if (it.fom > LocalDate.now()) 0 else beregnEtterbetaling(it.posteringer),
+                    totalFeilutbetaling = beregnFeilutbetaling(it.posteringer),
+                )
+            }
+        return SimuleringResponsDto(oppsummeringer = oppsummeringer, detaljer = detaljer)
     }
+
+    private fun beregnTidligereUtbetalt(posteringer: List<Postering>): Int =
+        abs(posteringer.summerBareNegativePosteringer(PosteringType.YTELSE))
+
+    private fun beregnNyUtbetaling(posteringer: List<Postering>): Int =
+        posteringer.summerBarePositivePosteringer(PosteringType.YTELSE) -
+            posteringer.summerBarePositivePosteringer(PosteringType.FEILUTBETALING)
+
+    /**
+     * Hvis perioden har en positiv feilutbetaling, kan det per def ikke være noen etterbetaling (det overskytende beløpet ville i så fall kansellert ut feilutbetalingen)
+     * Hvis perioden har en negativ feilutbetaling, betyr det at man øker ytelsen i en periode det er registrert feilutbetaling på tidligere og tilbakekrevingsbehandlingen ikke er avsluttet.
+     * Ved iverksetting av vedtaket ville feilutbetalingen i OS blitt redusert tilsvarende beløpet på posteringen for den negative feilutbetalingen.
+     */
+    private fun beregnEtterbetaling(posteringer: List<Postering>): Int =
+        if (detFinnesPositivFeilutbetaling(posteringer)) {
+            0
+        } else {
+            beregnResultat(posteringer) - abs(posteringer.summerBareNegativePosteringer(PosteringType.FEILUTBETALING))
+        }
+
+    private fun beregnFeilutbetaling(posteringer: List<Postering>): Int =
+        posteringer.summerBarePositivePosteringer(PosteringType.FEILUTBETALING)
+
+    private fun beregnResultat(posteringer: List<Postering>): Int =
+        if (detFinnesPositivFeilutbetaling(posteringer)) {
+            -posteringer.summerBarePositivePosteringer(PosteringType.FEILUTBETALING)
+        } else {
+            beregnNyUtbetaling(posteringer) - beregnTidligereUtbetalt(posteringer)
+        }
+
+    private fun detFinnesPositivFeilutbetaling(posteringer: List<Postering>): Boolean =
+        posteringer.any { it.type == PosteringType.FEILUTBETALING && it.beløp > 0 }
+
+    private fun List<Postering>.summerBarePositivePosteringer(type: PosteringType): Int =
+        this.filter { it.beløp > 0 && it.type == type }.sumOf { it.beløp }
+
+    private fun List<Postering>.summerBareNegativePosteringer(type: PosteringType): Int =
+        this.filter { it.beløp < 0 && it.type == type }.sumOf { it.beløp }
 }

--- a/src/main/kotlin/no/nav/utsjekk/simulering/domene/SimuleringDetaljer.kt
+++ b/src/main/kotlin/no/nav/utsjekk/simulering/domene/SimuleringDetaljer.kt
@@ -12,10 +12,10 @@ data class SimuleringDetaljer(
 data class Periode(
     val fom: LocalDate,
     val tom: LocalDate,
-    val posteringer: List<SimulertPostering>,
+    val posteringer: List<Postering>,
 )
 
-data class SimulertPostering(
+data class Postering(
     val fagområde: Fagområde,
     val sakId: String,
     val fom: LocalDate,

--- a/src/test/kotlin/no/nav/utsjekk/simulering/client/dto/MapperTest.kt
+++ b/src/test/kotlin/no/nav/utsjekk/simulering/client/dto/MapperTest.kt
@@ -4,9 +4,9 @@ import no.nav.utsjekk.kontrakter.felles.Fagsystem
 import no.nav.utsjekk.simulering.client.dto.Mapper.tilSimuleringDetaljer
 import no.nav.utsjekk.simulering.domene.Fagområde
 import no.nav.utsjekk.simulering.domene.Periode
+import no.nav.utsjekk.simulering.domene.Postering
 import no.nav.utsjekk.simulering.domene.PosteringType
 import no.nav.utsjekk.simulering.domene.SimuleringDetaljer
-import no.nav.utsjekk.simulering.domene.SimulertPostering
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
@@ -44,7 +44,7 @@ class MapperTest {
                                         feilkonto = false,
                                         detaljer =
                                             listOf(
-                                                Postering(
+                                                PosteringDto(
                                                     type = "YTEL",
                                                     faktiskFom = DATO_1_MAI,
                                                     faktiskTom = DATO_1_MAI,
@@ -74,7 +74,7 @@ class MapperTest {
                             tom = DATO_1_MAI,
                             posteringer =
                                 listOf(
-                                    SimulertPostering(
+                                    Postering(
                                         fagområde = Fagområde.TILLEGGSSTØNADER,
                                         sakId = SAK_ID,
                                         fom = DATO_1_MAI,
@@ -113,7 +113,7 @@ class MapperTest {
                                         feilkonto = false,
                                         detaljer =
                                             listOf(
-                                                Postering(
+                                                PosteringDto(
                                                     type = "YTEL",
                                                     faktiskFom = DATO_1_MAI,
                                                     faktiskTom = DATO_1_MAI,
@@ -134,7 +134,7 @@ class MapperTest {
                                         feilkonto = false,
                                         detaljer =
                                             listOf(
-                                                Postering(
+                                                PosteringDto(
                                                     type = "YTEL",
                                                     faktiskFom = DATO_15_MAI,
                                                     faktiskTom = DATO_15_MAI,
@@ -164,7 +164,7 @@ class MapperTest {
                             tom = DATO_1_MAI,
                             posteringer =
                                 listOf(
-                                    SimulertPostering(
+                                    Postering(
                                         fagområde = Fagområde.TILLEGGSSTØNADER,
                                         sakId = SAK_ID,
                                         fom = DATO_1_MAI,
@@ -173,7 +173,7 @@ class MapperTest {
                                         type = PosteringType.YTELSE,
                                         klassekode = KLASSEKODE,
                                     ),
-                                    SimulertPostering(
+                                    Postering(
                                         fagområde = Fagområde.TILLEGGSSTØNADER_ARENA,
                                         sakId = "ARENA-ID",
                                         fom = DATO_15_MAI,
@@ -212,7 +212,7 @@ class MapperTest {
                                         feilkonto = false,
                                         detaljer =
                                             listOf(
-                                                Postering(
+                                                PosteringDto(
                                                     type = "YTEL",
                                                     faktiskFom = DATO_1_MAI,
                                                     faktiskTom = DATO_1_MAI,
@@ -233,7 +233,7 @@ class MapperTest {
                                         feilkonto = false,
                                         detaljer =
                                             listOf(
-                                                Postering(
+                                                PosteringDto(
                                                     type = "YTEL",
                                                     faktiskFom = DATO_15_MAI,
                                                     faktiskTom = DATO_15_MAI,
@@ -263,7 +263,7 @@ class MapperTest {
                             tom = DATO_1_MAI,
                             posteringer =
                                 listOf(
-                                    SimulertPostering(
+                                    Postering(
                                         fagområde = Fagområde.TILLEGGSSTØNADER,
                                         sakId = SAK_ID,
                                         fom = DATO_1_MAI,

--- a/src/test/kotlin/no/nav/utsjekk/simulering/domene/OppsummeringGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/utsjekk/simulering/domene/OppsummeringGeneratorTest.kt
@@ -3,7 +3,6 @@ package no.nav.utsjekk.simulering.domene
 import no.nav.utsjekk.simulering.api.OppsummeringForPeriode
 import no.nav.utsjekk.simulering.api.SimuleringResponsDto
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
@@ -17,8 +16,8 @@ class OppsummeringGeneratorTest {
     }
 
     @Test
-    @Disabled
     fun `skal lage oppsummering for ny utbetaling`() {
+        val fremtidigPeriode = LocalDate.now().plusMonths(1)
         val simuleringDetaljer =
             SimuleringDetaljer(
                 gjelderId = PERSONIDENT,
@@ -27,15 +26,15 @@ class OppsummeringGeneratorTest {
                 perioder =
                     listOf(
                         Periode(
-                            fom = DATO_1_MAI,
-                            tom = DATO_1_MAI,
+                            fom = fremtidigPeriode,
+                            tom = fremtidigPeriode,
                             posteringer =
                                 listOf(
-                                    SimulertPostering(
+                                    Postering(
                                         fagområde = Fagområde.TILLEGGSSTØNADER,
                                         sakId = SAK_ID,
-                                        fom = DATO_1_MAI,
-                                        tom = DATO_1_MAI,
+                                        fom = fremtidigPeriode,
+                                        tom = fremtidigPeriode,
                                         beløp = 800,
                                         type = PosteringType.YTELSE,
                                         klassekode = KLASSEKODE,
@@ -50,12 +49,11 @@ class OppsummeringGeneratorTest {
                 oppsummeringer =
                     listOf(
                         OppsummeringForPeriode(
-                            fom = DATO_1_MAI,
-                            tom = DATO_1_MAI,
+                            fom = fremtidigPeriode,
+                            tom = fremtidigPeriode,
                             tidligereUtbetalt = 0,
                             nyUtbetaling = 800,
-                            // TODO hva bør denne logisk være for nye utbetalinger? Etterbetaling for perioder tom. dagens dato, ikke etterbetaling for fremtidig?
-                            totalEtterbetaling = 800,
+                            totalEtterbetaling = 0,
                             totalFeilutbetaling = 0,
                         ),
                     ),
@@ -66,7 +64,6 @@ class OppsummeringGeneratorTest {
     }
 
     @Test
-    @Disabled
     fun `skal lage oppsummering for etterbetaling`() {
         val simuleringDetaljer =
             SimuleringDetaljer(
@@ -80,7 +77,7 @@ class OppsummeringGeneratorTest {
                             tom = DATO_1_MAI,
                             posteringer =
                                 listOf(
-                                    SimulertPostering(
+                                    Postering(
                                         type = PosteringType.YTELSE,
                                         fom = DATO_1_MAI,
                                         tom = DATO_1_MAI,
@@ -89,7 +86,7 @@ class OppsummeringGeneratorTest {
                                         sakId = SAK_ID,
                                         klassekode = KLASSEKODE,
                                     ),
-                                    SimulertPostering(
+                                    Postering(
                                         type = PosteringType.YTELSE,
                                         fom = DATO_1_MAI,
                                         tom = DATO_1_MAI,
@@ -123,7 +120,6 @@ class OppsummeringGeneratorTest {
     }
 
     @Test
-    @Disabled
     fun `skal lage oppsummering for feilutbetaling`() {
         val simuleringDetaljer =
             SimuleringDetaljer(
@@ -137,7 +133,7 @@ class OppsummeringGeneratorTest {
                             tom = DATO_1_MAI,
                             posteringer =
                                 listOf(
-                                    SimulertPostering(
+                                    Postering(
                                         type = PosteringType.YTELSE,
                                         fom = DATO_1_MAI,
                                         tom = DATO_1_MAI,
@@ -146,7 +142,7 @@ class OppsummeringGeneratorTest {
                                         sakId = SAK_ID,
                                         klassekode = KLASSEKODE,
                                     ),
-                                    SimulertPostering(
+                                    Postering(
                                         type = PosteringType.YTELSE,
                                         fom = DATO_1_MAI,
                                         tom = DATO_1_MAI,
@@ -155,7 +151,7 @@ class OppsummeringGeneratorTest {
                                         sakId = SAK_ID,
                                         klassekode = KLASSEKODE,
                                     ),
-                                    SimulertPostering(
+                                    Postering(
                                         type = PosteringType.FEILUTBETALING,
                                         fom = DATO_1_MAI,
                                         tom = DATO_1_MAI,
@@ -164,7 +160,7 @@ class OppsummeringGeneratorTest {
                                         sakId = SAK_ID,
                                         klassekode = KLASSEKODE,
                                     ),
-                                    SimulertPostering(
+                                    Postering(
                                         type = PosteringType.MOTPOSTERING,
                                         fom = DATO_1_MAI,
                                         tom = DATO_1_MAI,
@@ -173,7 +169,7 @@ class OppsummeringGeneratorTest {
                                         sakId = SAK_ID,
                                         klassekode = KLASSEKODE,
                                     ),
-                                    SimulertPostering(
+                                    Postering(
                                         type = PosteringType.YTELSE,
                                         fom = DATO_1_MAI,
                                         tom = DATO_1_MAI,


### PR DESCRIPTION
Verdt å merke seg:
* Har valgt at fremtidige perioder per def ikke kan ha etterbetaling. Da er det bare en ny utbetaling.
* Ved beregning av ny utbetaling trekker vi fra positive feilutbetalinger fordi det ved feilutbetaling alltid vil være en ekstra postering på ytelsen som tilsvarer feilutbetalingen slik at regnskapet går i 0. Må derfor trekke fra feilutbetalingen for å kansellere denne ekstra posteringen.